### PR TITLE
Increase the body parser limit.

### DIFF
--- a/src/phantesta.js
+++ b/src/phantesta.js
@@ -327,7 +327,7 @@ Phantesta.prototype.startServer = function(options) {
 
   var app = express();
 
-  app.use(bodyParser.json());
+  app.use(bodyParser.json({limit: '200mb'}));
   app.get('/', function(req, resp) {
     resp.sendFile(path.resolve(__dirname, '../phantesta-server.html'));
   });


### PR DESCRIPTION
This manifested in failing to submit a large number of changes at once, stack trace in server would be:
```
Error: request entity too large
    at readStream (/parsehub/registry.parsehub.com/ci/firefox_ui_tests/phuitest/node_modules/raw-body/index.js:196:17)
    at getRawBody (/parsehub/registry.parsehub.com/ci/firefox_ui_tests/phuitest/node_modules/raw-body/index.js:106:12)
    at read (/parsehub/registry.parsehub.com/ci/firefox_ui_tests/phuitest/node_modules/body-parser/lib/read.js:76:3)
    at jsonParser (/parsehub/registry.parsehub.com/ci/firefox_ui_tests/phuitest/node_modules/body-parser/lib/types/json.js:127:5)
    at Layer.handle [as handle_request] (/parsehub/registry.parsehub.com/ci/firefox_ui_tests/phuitest/node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (/parsehub/registry.parsehub.com/ci/firefox_ui_tests/phuitest/node_modules/express/lib/router/index.js:312:13)
    at /parsehub/registry.parsehub.com/ci/firefox_ui_tests/phuitest/node_modules/express/lib/router/index.js:280:7
    at Function.process_params (/parsehub/registry.parsehub.com/ci/firefox_ui_tests/phuitest/node_modules/express/lib/router/index.js:330:12)
    at next (/parsehub/registry.parsehub.com/ci/firefox_ui_tests/phuitest/node_modules/express/lib/router/index.js:271:10)
    at expressInit (/parsehub/registry.parsehub.com/ci/firefox_ui_tests/phuitest/node_modules/express/lib/middleware/init.js:33:5)

```
