### PR TITLE
remove download server bin from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "phantesta",
-  "version": "4.0.21",
+  "version": "4.0.22",
   "description": "Screenshot diffing for tests",
   "main": "dist/phantesta.js",
   "scripts": {
@@ -13,7 +13,6 @@
   "bin": {
     "phantesta-server": "dist/bin/phantesta-server.js",
     "remote-phantesta-server": "dist/bin/start-remote-server.js",
-    "download-from-remote-phantesta": "dist/bin/download-server.js",
     "upload-to-remote-phantesta": "dist/bin/upload-server.js"
   },
   "repository": {


### PR DESCRIPTION
The file was removed in one of the previous commits but wasn't from the package.json. This prevents the lib from being installed when it tries to add bins to the PATH.