### PR TITLE
support custom screenshot extension upload

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,6 +4,9 @@
     "stage-2"
   ],
   "plugins": [
-    "transform-object-rest-spread"
+    "transform-object-rest-spread",
+    ["transform-runtime", {
+      "regenerator": true
+    }]
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "phantesta",
-  "version": "4.0.19",
+  "version": "4.0.22",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -831,6 +831,15 @@
       "dev": true,
       "requires": {
         "regenerator-transform": "^0.10.0"
+      }
+    },
+    "babel-plugin-transform-runtime": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz",
+      "integrity": "sha1-iEkNRGUC6puOfvsP4J7E2ZR5se4=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-strict-mode": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "phantesta",
-  "version": "4.0.22",
+  "version": "4.0.23",
   "description": "Screenshot diffing for tests",
   "main": "dist/phantesta.js",
   "scripts": {
@@ -39,6 +39,7 @@
   "devDependencies": {
     "babel-cli": "6.26.0",
     "babel-plugin-transform-object-rest-spread": "6.26.0",
+    "babel-plugin-transform-runtime": "6.23.0",
     "babel-preset-es2015": "6.24.1",
     "babel-preset-stage-2": "6.24.1"
   }

--- a/src/bin/upload-server.js
+++ b/src/bin/upload-server.js
@@ -43,9 +43,23 @@ let sendScreenshots = function(identifier) {
       let newImg = phantesta.getNewPath(name);
       let diffImg = phantesta.getDiffPath(name);
 
-      _sendFile(goodImg, name + phantesta.options.goodExt, identifier);
-      _sendFile(newImg, name + phantesta.options.newExt, identifier);
-      _sendFile(diffImg, name + phantesta.options.diffExt, identifier);
+      _sendFile(
+        goodImg,
+        _getFileName(name, 'good', _getFileType(phantesta.options.goodExt)),
+        identifier
+      );
+
+      _sendFile(
+        newImg,
+        _getFileName(name, 'new', _getFileType(phantesta.options.newExt)),
+        identifier
+      );
+
+      _sendFile(
+        diffImg,
+        _getFileName(name, 'diff', _getFileType(phantesta.options.diffExt)),
+        identifier
+      );
     }
     if (files.length) {
       console.log(
@@ -57,8 +71,16 @@ let sendScreenshots = function(identifier) {
   })
 };
 
-let _sendFile = function(file, fileName) {
+const _getFileType = function(ext) {
+  const splitExt = ext.split('.');
+  return splitExt[splitExt.length - 1];
+};
 
+const _getFileName = function(fileName, remoteExt, fileType) {
+  return `${fileName}.${remoteExt}.${fileType}`;
+};
+
+let _sendFile = function(file, fileName) {
   let newImageStream = fs.createReadStream(file);
 
   let newImageReq = request.post(
@@ -68,9 +90,11 @@ let _sendFile = function(file, fileName) {
   newImageReq.on('drain', function () {
     newImageStream.resume();
   });
+
   newImageReq.on('error', function (err) {
     console.error('cannot send file ' + fileName + ': ' + err);
   });
+
   newImageReq.on('response', function(resp) {
     if (resp.statusCode !== 200) {
       resp.on('data', function(data) {
@@ -79,12 +103,15 @@ let _sendFile = function(file, fileName) {
       });
     }
   });
+
   newImageStream.on('end', function () {
     console.log('file uploaded');
   });
+
   newImageStream.on('error', function (err) {
     console.error('cannot send file ' + fileName + ': ' + err);
   });
+
   newImageStream.pipe(newImageReq);
 };
 

--- a/src/remote_server.js
+++ b/src/remote_server.js
@@ -112,17 +112,16 @@ class RemoteServer {
     app.post('/:identifier/upload/:fileName',  (req, res) => {
       const {identifier, fileName} = req.params;
       try {
-        let dir = path.dirname(fileName);
         let name = path.basename(fileName);
 
         let identifierFolderPath = `${this.identifierPath(identifier)}`;
-        let filePath = `${this.identifierPath(identifier)}/${dir}`;
 
         if (!fs.existsSync(identifierFolderPath)) {
           fs.mkdirSync(identifierFolderPath);
         }
+
         //pipe it to /commitNumber/screenShots
-        let stream = fs.createWriteStream(`${filePath}/${name}`);
+        let stream = fs.createWriteStream(`${identifierFolderPath}/${name}`);
 
         req.pipe(stream);
 


### PR DESCRIPTION
1. Added a missing babel plugin. Could not run phatesta locally without it.
2. Before sending the screenshot I normalize the name to a common format. No changes to remote server required in this case (except there's no need to create subfolders for images, so that was deleted). It works with `<filename>.<scrExt>.<ext>` common format, no matter what custom extension we specify for upload script.